### PR TITLE
Hook/Module for dracut

### DIFF
--- a/contrib/dracut/install
+++ b/contrib/dracut/install
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# By Georg Pfuetzenreuter <mail@georg-pfuetzenreuter.net>
+
+install() {
+        SRC="$1"
+        DST="$2"
+        cp "$SRC" "$DST"
+        chown root:root "$DST"
+        chmod 755 "$DST"
+}
+
+# 89 *should* not be occupied by system modules
+MODULEDIR="/usr/lib/dracut/modules.d/89luksrku/"
+
+install luksrku-script.sh "$MODULEDIR"
+install module-setup.sh "$MODULEDIR"

--- a/contrib/dracut/luksrku-script.sh
+++ b/contrib/dracut/luksrku-script.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# By Georg Pfuetzenreuter <mail@georg-pfuetzenreuter.net>
+
+if [ ! -f /etc/luksrku-client.bin ]; then
+        exit 1
+fi
+
+# on wicked based SUSE systems, the network-legacy module applies network configuration from the booted system, but it does not start the interface in time
+ifup eth0
+
+/sbin/luksrku client -v -t 10 /etc/luksrku-client.bin
+luksrku_result="$?"
+
+# unfortunately systemd does not seem to wait for the initqueue to finish before starting the password agent - hence we make the password prompt fail if luksrku succeeded 
+if [ "$luksrku_result" = "0" ]; then
+        echo "" | systemd-tty-ask-password-agent
+fi
+
+exit 0

--- a/contrib/dracut/module-setup.sh
+++ b/contrib/dracut/module-setup.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+#
+# By Georg Pfuetzenreuter <mail@georg-pfuetzenreuter.net>
+
+# called by dracut
+check() {
+        if [ ! -f /etc/luksrku-client.bin ]; then
+                exit 0
+        fi
+
+        require_binaries /usr/local/sbin/luksrku cryptsetup
+}
+
+# called by dracut
+depends() {
+        echo network
+}
+
+cmdline() {
+        printf "%s" "rd.neednet=1"
+}
+
+# called by dracut
+install() {
+        inst /usr/local/sbin/luksrku /sbin/luksrku
+        inst cryptsetup
+        inst_hook initqueue 10 "$moddir/luksrku-script.sh"
+        inst_simple /etc/luksrku-client.bin /etc/luksrku-client.bin
+        local _netconf=$(cmdline)
+        printf "%s\n" "$_netconf" >> "$initdir/etc/cmdline.d/89luksrku.conf"
+}


### PR DESCRIPTION
Signed-off-by: Georg Pfuetzenreuter <mail@georg-pfuetzenreuter.net>

Hi,

this has been tested on openSUSE Leap, but it should work equally well with other `dracut` + `systemd-cryptsetup` based distributions.

Best,
Georg